### PR TITLE
過去日付の面接を持つユーザーに対して複数の面談が承認できてしまうバグの修正

### DIFF
--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -33,7 +33,7 @@ class InterviewsController < ApplicationController
       if @interview.approval?
         # 承認された面接以外のそのユーザーの面接のapproval_statusをdisapproval(拒否)に設定
         @user.interviews.where.not(id: params[:id]).each do |interview|
-          interview.disapproval!
+          interview.update_attribute(:approval_status, :disapproval)
         end
       end
       redirect_to user_interview_path(current_user, @interview), notice: "面接を更新しました。"


### PR DESCRIPTION
原因と対応
---
過去日付の面接を持つユーザーの面接ステータスを更新するタイミングで、面接日付のバリデーションが引っかかってしまいエラーで落ちていた。

面接承認後、その他の面接ステータスを拒否に変更する際のバリデーションをスキップすることにより対応。

動作確認方法
---
過去日付を面接を持つユーザーに対して面接の承認を行う。