### PR TITLE
承認が押された際に、両者に面接日が決ったことを伝えるメールの実装

### DIFF
--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -35,7 +35,7 @@ class InterviewsController < ApplicationController
         @user.interviews.where.not(id: params[:id]).each do |interview|
           interview.update_attribute(:approval_status, :disapproval)
         end
-        InterviewMailer.decide(@user, current_user).deliver_now
+        InterviewMailer.decide(@interview, current_user).deliver_now
       end
       redirect_to user_interview_path(current_user, @interview), notice: "面接を更新しました。"
     else

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -35,6 +35,7 @@ class InterviewsController < ApplicationController
         @user.interviews.where.not(id: params[:id]).each do |interview|
           interview.update_attribute(:approval_status, :disapproval)
         end
+        InterviewMailer.decide(@user, current_user).deliver_now
       end
       redirect_to user_interview_path(current_user, @interview), notice: "面接を更新しました。"
     else

--- a/app/mailers/interview_mailer.rb
+++ b/app/mailers/interview_mailer.rb
@@ -6,11 +6,10 @@ class InterviewMailer < ApplicationMailer
          subject: '面接希望日が決まりました。'
   end
 
-  def decide(interviewee, interviewer)
-    @interviewee = interviewee
-    @interviewee_interviews = interviewee.interviews
+  def decide(approved_interview, interviewer)
+    @approved_interview = approved_interview
     @interviewer = interviewer
-    mail to: [@interviewee.email, @interviewer.email],
+    mail to: [@approved_interview.user.email, @interviewer.email],
          subject: '面接日時が確定しました。'
   end
 end

--- a/app/mailers/interview_mailer.rb
+++ b/app/mailers/interview_mailer.rb
@@ -5,4 +5,12 @@ class InterviewMailer < ApplicationMailer
     mail to: interviewer_email,
          subject: '面接希望日が決まりました。'
   end
+
+  def decide(interviewee, interviewer)
+    @interviewee = interviewee
+    @interviewee_interviews = interviewee.interviews
+    @interviewer = interviewer
+    mail to: [@interviewee.email, @interviewer.email],
+         subject: '面接日時が確定しました。'
+  end
 end

--- a/app/views/interview_mailer/decide.html.erb
+++ b/app/views/interview_mailer/decide.html.erb
@@ -1,7 +1,6 @@
-<%= @interviewee.profile.name %> さんの面接時間が <%= @interviewer.profile.name %> さんによって、以下の内容で、承認されました。<br>
-<% @interviewee_interviews.each do |interview| %>
-  <%= "日程:#{l interview.interview_datetime, format: :long}" if interview.approval? %><br>
-<% end %>
+<%= @approved_interview.user.profile.name %> さんの面接時間が <%= @interviewer.profile.name %> さんによって、以下の内容で、承認されました。<br>
+
+<%= "日程:#{l @approved_interview.interview_datetime, format: :long}" %><br>
 
 場所は、株式会社フィードフォースで行います。<br>
 今後の連絡は担当人事の方から再度連絡させていただきます。<br>

--- a/app/views/interview_mailer/decide.html.erb
+++ b/app/views/interview_mailer/decide.html.erb
@@ -1,0 +1,9 @@
+<%= @interviewee.profile.name %> さんの面接時間が <%= @interviewer.profile.name %> さんによって、以下の内容で、承認されました。<br>
+<% @interviewee_interviews.each do |interview| %>
+  <%= "日程:#{l interview.interview_datetime, format: :long}" if interview.approval? %><br>
+<% end %>
+
+場所は、株式会社フィードフォースで行います。<br>
+今後の連絡は担当人事の方から再度連絡させていただきます。<br>
+
+よろしくお願いします。

--- a/app/views/interview_mailer/decide.text.erb
+++ b/app/views/interview_mailer/decide.text.erb
@@ -1,7 +1,6 @@
-<%= @interviewee.profile.name %> さんの面接時間が <%= @interviewer.profile.name %> さんによって、以下の内容で、承認されました。<br>
-<% @interviewee_interviews.each do |interview| %>
-  <%= "日程:#{l interview.interview_datetime, format: :long}" if interview.approval? %><br>
-<% end %>
+<%= @approved_interview.user.profile.name %> さんの面接時間が <%= @interviewer.profile.name %> さんによって、以下の内容で、承認されました。<br>
+
+<%= "日程:#{l @approved_interview.interview_datetime, format: :long}" %><br>
 
 場所は、株式会社フィードフォースで行います。<br>
 今後の連絡は担当人事の方から再度連絡させていただきます。<br>

--- a/app/views/interview_mailer/decide.text.erb
+++ b/app/views/interview_mailer/decide.text.erb
@@ -1,0 +1,9 @@
+<%= @interviewee.profile.name %> さんの面接時間が <%= @interviewer.profile.name %> さんによって、以下の内容で、承認されました。<br>
+<% @interviewee_interviews.each do |interview| %>
+  <%= "日程:#{l interview.interview_datetime, format: :long}" if interview.approval? %><br>
+<% end %>
+
+場所は、株式会社フィードフォースで行います。<br>
+今後の連絡は担当人事の方から再度連絡させていただきます。<br>
+
+よろしくお願いします。


### PR DESCRIPTION
やったこと
----
面接承認時に面接確定メールを面接者、面接官に送信する機能の実装

動作確認方法
---
- [ ] 自分以外のユーザーの面接一覧から承認する面接を選択する
- [ ] その後、面接が承認されたユーザーと自分あてにメールが届いてることを確認する

確認URL
---
https://e-navigator-hy4yh.herokuapp.com
